### PR TITLE
Simplify installation process with deb files

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -114,8 +114,7 @@ RUN rm openjdk11.tar.gz
 ENV PATH $PATH:/jdk-11.0.2/bin
 
 # super unko...
-RUN git clone https://github.com/greymd/super_unko.git
-ENV PATH $PATH:/super_unko
+RUN curl -OL --retry 3 https://git.io/superunko.deb && dpkg -i superunko.deb && rm superunko.deb
 
 # nameko.svg
 RUN wget https://gist.githubusercontent.com/KeenS/6194e6ef1a151c9ea82536d5850b8bc7/raw/85af9ec757308b8ca4effdf24221f642cb34703b/nameko.svg
@@ -179,10 +178,5 @@ RUN rm -rf bash-5.0
 
 RUN curl -O https://www.unicode.org/Public/UCD/latest/ucd/NormalizationTest.txt
 RUN curl -O https://www.unicode.org/Public/UCD/latest/ucd/NamesList.txt
-
-#FIXME
-WORKDIR /super_unko
-RUN bash install.sh
-WORKDIR /
 
 CMD bash

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,6 @@ RUN apt-get update -y && apt-get install -y ruby \
       perl\
       toilet\
       figlet\
-      haskell-platform\
       libncurses5-dev\
       git\
       build-essential\
@@ -84,14 +83,9 @@ RUN gem install cureutils matsuya takarabako snacknomama rubipara marky_markov
 RUN pip3 install yq faker sympy numpy scipy matplotlib xonsh pillow asciinema
 RUN pip install sympy numpy scipy matplotlib pillow
 
-
 # install egzact && egison
-RUN cabal update && cabal install egison
-RUN git clone https://github.com/greymd/egzact.git
-WORKDIR egzact
-RUN make install
-WORKDIR /
-ENV PATH /root/.cabal/bin:/root/.egison/bin:$PATH
+RUN curl -OL --retry 3 https://git.io/egison-3.7.14.x86_64.deb && dpkg -i ./egison-3.7.14.x86_64.deb && rm ./egison-3.7.14.x86_64.deb
+RUN curl -OL --retry 3 https://git.io/egzact-1.3.1.deb && dpkg -i ./egzact-1.3.1.deb && rm ./egzact-1.3.1.deb
 
 # install node and faker-cli, chemi
 RUN npm cache clean && npm install n -g

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,7 @@ RUN apt-get update -y && apt-get install -y ruby \
       perl\
       toilet\
       figlet\
-      libncurses5-dev\
+      haskell-platform\
       git\
       build-essential\
       mecab libmecab-dev mecab-ipadic mecab-ipadic-utf8 python-mecab\


### PR DESCRIPTION
Egison、egzact、super_unkoに関しては、debパッケージファイルを用意しましたので (配布元: [Egison](https://github.com/egison/egison-package-builder#apt-or-dpkg)、[egzact](https://github.com/greymd/egzact#linux-execute-following-commands)、[super_unko](https://github.com/unkontributors/super_unko#installation))、そちらを使ったインストール方法に切り替えました。
Dockerhub環境にはなりますが、ビルド(& コマンド実行)ができることは確認してます。 [link](https://hub.docker.com/r/greymd/shellgeibot/builds)
Egisonのビルドの必要がなくなりましたので、ビルド時間の短縮になる…と思います。

なお、Egisonのビルドに必要だったと思われるlibncurses5-devは削除しました。
Haskellユーザのためにhaskell-platformは残してあります。