### PR TITLE
Dockerイメージのビルドを高速化

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,24 +26,46 @@ jobs:
       - store_artifacts:
           path: /go/src/github.com/theoldmoon0602/ShellGeiBot/ShellGeiBot
   image-build:
+    environment:
+      DOCKER_IMAGE: theoldmoon0602/shellgeibot
     docker:
       - image: docker:stable
+        environment:
+          DOCKER_BUILDKIT: "1"  # Enable Docker BuildKit
     steps:
       - checkout
-      - setup_remote_docker
+      - setup_remote_docker:
+          docker_layer_caching: true  # BuildKit の DLC はまだ効かないっぽい
+          version: "18.09.3"
       - run:
-          command: "sh -c 'docker build . -t theoldmoon0602/shellgeibot:`date +%Y%m%d`'"
+          name: Setup Build environment
+          command: |
+            apk add bash bats --no-progress
+            bats --version
+            docker version
       - run:
+          name: Login Docker Hub
           command: docker login -u ${DOCKER_USER} -p ${DOCKER_PASS}
       - run:
-          command: "sh -c 'docker push theoldmoon0602/shellgeibot:`date +%Y%m%d`'"
+          name: Build Docker image
+          command: docker build -t ${DOCKER_IMAGE} --progress=plain .
+      - run:
+          name: Test Docker image
+          command: DOCKER_IMAGE=${DOCKER_IMAGE} bats docker_image.bats
+      - run:
+          name: Push Docker image to Docker Hub
+          command: |
+            # docker push ${DOCKER_IMAGE}:latest
+            DATE_TAG=$(date +%Y%m%d)
+            docker tag ${DOCKER_IMAGE}:latest ${DOCKER_IMAGE}:${DATE_TAG}
+            docker push ${DOCKER_IMAGE}:${DATE_TAG}
+
 workflows:
   version: 2
   commit-workflow:
     jobs:
       - build
       - image-build
-
   scheduled-workflow:
     triggers:
       - schedule:
@@ -54,5 +76,3 @@ workflows:
                 - master
     jobs:
       - image-build
-
-

--- a/Dockerfile
+++ b/Dockerfile
@@ -61,14 +61,6 @@ RUN apt install -y -qq curl git mono-mcs
 RUN git clone --depth 1 https://github.com/xztaityozx/noc.git
 RUN mcs noc/noc/noc/Program.cs
 
-## Rust
-FROM ubuntu:19.04 as rust-builder
-RUN apt update -qq
-RUN apt install -y -qq curl build-essential
-RUN curl -sfSL https://sh.rustup.rs | sh -s -- -y
-ENV PATH /root/.cargo/bin:$PATH
-RUN cargo install --git https://github.com/lotabout/rargs.git
-
 ## General
 FROM ubuntu:19.04 as general-builder
 RUN apt update -qq
@@ -165,9 +157,6 @@ RUN git clone --depth 1 https://github.com/ryuichiueda/ShellGeiData.git
 RUN git clone --depth 1 https://github.com/ryuichiueda/ImageGeneratorForShBot.git
 ENV PATH /ImageGeneratorForShBot:$PATH
 
-# # nginx ... これ必要?
-# RUN /etc/init.d/nginx start
-
 # zws
 RUN curl -sfSLO https://raintrees.net/attachments/download/486/zws \
     && chmod +x zws
@@ -204,68 +193,73 @@ RUN curl -sfSLO https://www.unicode.org/Public/UCD/latest/ucd/NamesList.txt
 RUN --mount=type=cache,target=/var/cache/apt \
     --mount=type=cache,target=/var/lib/apt \
     apt update -qq && apt install -y -qq \
-      ruby \
-      ccze \
-      screen tmux \
-      ttyrec \
-      timidity abcmidi \
-      r-base \
-      boxes \
-      ash yash \
-      jq \
-      vim emacs \
-      nkf \
-      rs \
-      language-pack-ja \
-      pwgen \
-      bc \
-      perl \
-      toilet \
-      figlet \
-      haskell-platform \
-      mecab mecab-ipadic mecab-ipadic-utf8 \
-      bsdgames fortunes cowsay fortunes-off cowsay-off \
-      datamash \
-      gawk \
-      libxml2-utils \
-      zsh \
-      num-utils \
-      apache2-utils \
-      fish \
-      lolcat \
-      nyancat \
-      imagemagick \
-      moreutils \
-      strace \
-      whiptail \
-      pandoc \
-      postgresql-common \
-      postgresql-client-common \
-      icu-devtools \
-      tcsh \
-      libskk-dev \
-      libkkc-utils \
-      morsegen \
-      dc \
-      telnet \
-      busybox \
-      parallel \
-      rename \
-      mt-st \
-      ffmpeg \
-      kakasi \
-      dateutils \
-      fonts-ipafont fonts-vlgothic \
-      inkscape gnuplot \
-      qrencode \
-      fonts-nanum fonts-symbola fonts-noto-color-emoji \
-      sl \
-      chromium-browser chromium-chromedriver nginx \
-      screenfetch \
-      mono-runtime \
-      firefox \
-      lua5.3 php7.2 php7.2-cli php7.2-common \
+      ruby\
+      ccze\
+      screen tmux\
+      ttyrec\
+      timidity abcmidi\
+      r-base\
+      boxes\
+      ash yash\
+      jq\
+      vim emacs\
+      nkf\
+      rs\
+      language-pack-ja\
+      pwgen\
+      bc\
+      perl\
+      toilet\
+      figlet\
+      haskell-platform\
+      mecab mecab-ipadic mecab-ipadic-utf8\
+      bsdgames fortunes cowsay fortunes-off cowsay-off\
+      datamash\
+      gawk\
+      libxml2-utils\
+      zsh\
+      num-utils\
+      apache2-utils\
+      fish\
+      lolcat\
+      nyancat\
+      imagemagick\
+      moreutils\
+      strace\
+      whiptail\
+      pandoc\
+      postgresql-common\
+      postgresql-client-common\
+      icu-devtools\
+      tcsh\
+      libskk-dev\
+      libkkc-utils\
+      morsegen\
+      dc\
+      telnet\
+      busybox\
+      parallel\
+      rename\
+      mt-st\
+      ffmpeg\
+      kakasi\
+      dateutils\
+      fonts-ipafont fonts-vlgothic\
+      inkscape gnuplot\
+      qrencode\
+      fonts-nanum fonts-symbola fonts-noto-color-emoji\
+      sl\
+      chromium-browser chromium-chromedriver nginx\
+      screenfetch\
+      mono-runtime\
+      firefox\
+      lua5.3 php7.2 php7.2-cli php7.2-common\
       nodejs
+
+## Rust
+RUN curl -sfSL https://sh.rustup.rs | sh -s -- -y
+ENV PATH /root/.cargo/bin:$PATH
+RUN cargo install --git https://github.com/lotabout/rargs.git
 
 # Go
 RUN curl -sfSL --retry 3 https://dl.google.com/go/go1.12.linux-amd64.tar.gz -o go.tar.gz \
@@ -274,11 +268,53 @@ RUN curl -sfSL --retry 3 https://dl.google.com/go/go1.12.linux-amd64.tar.gz -o g
 ENV GOPATH /root/go
 ENV PATH $PATH:/usr/local/go/bin:/root/go/bin
 COPY --from=go-builder /root/go/bin /root/go/bin
-RUN mkdir -p /root/go/src/github.com/YuheiNakasaka/sayhuuzoku/db/
-RUN curl -sfSL https://raw.githubusercontent.com/YuheiNakasaka/sayhuuzoku/master/db/data.db -o /root/go/src/github.com/YuheiNakasaka/sayhuuzoku/db/data.db
-RUN mkdir -p /root/go/src/github.com/YuheiNakasaka/sayhuuzoku/scraping/
-RUN curl -sfSL https://raw.githubusercontent.com/YuheiNakasaka/sayhuuzoku/master/scraping/shoplist.txt -o /root/go/src/github.com/YuheiNakasaka/sayhuuzoku/scraping/shoplist.txt
-RUN ln -s /root/go/src/github.com/YuheiNakasaka/sayhuuzoku/db /
+RUN mkdir -p /root/go/src/github.com/YuheiNakasaka/sayhuuzoku/db/ \
+    && curl -sfSL https://raw.githubusercontent.com/YuheiNakasaka/sayhuuzoku/master/db/data.db \
+      -o /root/go/src/github.com/YuheiNakasaka/sayhuuzoku/db/data.db \
+    && ln -s /root/go/src/github.com/YuheiNakasaka/sayhuuzoku/db / \
+    && mkdir -p /root/go/src/github.com/YuheiNakasaka/sayhuuzoku/scraping/ \
+    && curl -sfSL https://raw.githubusercontent.com/YuheiNakasaka/sayhuuzoku/master/scraping/shoplist.txt \
+      -o /root/go/src/github.com/YuheiNakasaka/sayhuuzoku/scraping/shoplist.txt \
+    && mkdir -p /usr/local/share/sayhuuzoku \
+    && curl -sfSL https://raw.githubusercontent.com/YuheiNakasaka/sayhuuzoku/master/README.md \
+      -o /usr/local/share/sayhuuzoku/README.md
+RUN mkdir -p /usr/local/share/gron \
+    && curl -sfSL https://raw.githubusercontent.com/tomnomnom/gron/master/LICENSE \
+      -o /usr/local/share/gron/LICENSE \
+    && curl -sfSL https://raw.githubusercontent.com/tomnomnom/gron/master/README.mkd \
+      -o /usr/local/share/gron/README.mkd
+RUN mkdir -p /usr/local/share/ttyrec2gif \
+    && curl -sfSL https://raw.githubusercontent.com/sugyan/ttyrec2gif/master/README.md \
+      -o /usr/local/share/ttyrec2gif/README.md \
+    && curl -sfSL https://raw.githubusercontent.com/sugyan/ttyrec2gif/master/LICENSE \
+      -o /usr/local/share/ttyrec2gif/LICENSE
+RUN mkdir -p /usr/local/share/owari \
+    && curl -sfSL https://raw.githubusercontent.com/xztaityozx/owari/master/README.md \
+      -o /usr/local/share/owari/README.md \
+    && curl -sfSL https://raw.githubusercontent.com/xztaityozx/owari/master/LICENSE \
+      -o /usr/local/share/owari/LICENSE
+RUN mkdir -p /usr/local/share/align \
+    && curl -sfSL https://raw.githubusercontent.com/jiro4989/align/master/README.adoc \
+      -o /usr/local/share/align/README.adoc \
+    && curl -sfSL https://raw.githubusercontent.com/jiro4989/align/master/LICENSE \
+      -o /usr/local/share/align/LICENSE
+RUN mkdir -p /usr/local/share/taishoku \
+    && curl -sfSL https://raw.githubusercontent.com/jiro4989/taishoku/master/README.adoc \
+      -o /usr/local/share/taishoku/README.adoc \
+    && curl -sfSL https://raw.githubusercontent.com/jiro4989/taishoku/master/LICENSE \
+      -o /usr/local/share/taishoku/LICENSE
+RUN mkdir -p /usr/local/share/textimg \
+    && curl -sfSL https://raw.githubusercontent.com/jiro4989/textimg/master/README.adoc \
+      -o /usr/local/share/textimg/README.adoc \
+    && curl -sfSL https://raw.githubusercontent.com/jiro4989/textimg/master/LICENSE \
+      -o /usr/local/share/textimg/LICENSE
+RUN mkdir -p /usr/local/share/ke2daira \
+    && curl -sfSL https://raw.githubusercontent.com/ryuichiueda/ke2daira/master/README.md \
+      -o /usr/local/share/ke2daira/README.md \
+    && curl -sfSL https://raw.githubusercontent.com/ryuichiueda/ke2daira/master/README.en.md \
+      -o /usr/local/share/ke2daira/README.en.md \
+    && curl -sfSL https://raw.githubusercontent.com/ryuichiueda/ke2daira/master/LICENSE \
+      -o /usr/local/share/ke2daira/LICENSE
 
 # Ruby
 COPY --from=ruby-builder /usr/local/bin /usr/local/bin
@@ -296,11 +332,8 @@ COPY --from=nodejs-builder /usr/local/lib/node_modules /usr/local/lib/node_modul
 
 # .NET
 COPY --from=dotnet-builder /noc/noc/noc/Program.exe /noc
-
-# Rust
-COPY --from=rust-builder /root/.cargo /root/.cargo
-RUN curl -sfSL https://sh.rustup.rs | sh -s -- -y
-ENV PATH /root/.cargo/bin:$PATH
+COPY --from=dotnet-builder /noc/LICENSE /usr/local/share/noc/LICENSE
+COPY --from=dotnet-builder /noc/README.md /usr/local/share/noc/README.md
 
 # gawk 5.0 / Open-usp-Tukubai
 COPY --from=general-builder /usr/local /usr/local

--- a/Dockerfile
+++ b/Dockerfile
@@ -148,14 +148,9 @@ RUN apt update -qq \
       mono-mcs mono-runtime\
       firefox\
       lua5.3 php7.2 php7.2-cli php7.2-common \
+      libedit-dev \
     && apt clean \
     && rm -rf /var/lib/apt/lists/
-
-# OpenJDK
-RUN curl -sfSL --retry 3 https://download.oracle.com/java/GA/jdk11/9/GPL/openjdk-11.0.2_linux-x64_bin.tar.gz -o openjdk11.tar.gz \
-    && tar xzf openjdk11.tar.gz \
-    && rm openjdk11.tar.gz
-ENV PATH $PATH:/jdk-11.0.2/bin
 
 # Julia
 RUN curl -sfSL --retry 3 https://julialang-s3.julialang.org/bin/linux/x64/1.1/julia-1.1.0-linux-x86_64.tar.gz -o julia.tar.gz \
@@ -173,6 +168,13 @@ RUN curl -sfSL --retry 3 http://www.jsoftware.com/download/j807/install/j807_lin
     && tar xvzf j.tar.gz \
     && rm j.tar.gz
 ENV PATH $PATH:/j64-807/bin
+
+# jconsole コマンドが JDK と J で重複するため、J の PATH を優先
+# OpenJDK
+RUN curl -sfSL --retry 3 https://download.oracle.com/java/GA/jdk11/9/GPL/openjdk-11.0.2_linux-x64_bin.tar.gz -o openjdk11.tar.gz \
+    && tar xzf openjdk11.tar.gz \
+    && rm openjdk11.tar.gz
+ENV PATH $PATH:/jdk-11.0.2/bin
 
 # home-commands (echo-sd)
 WORKDIR /root
@@ -252,6 +254,7 @@ ENV GOPATH /root/go
 ENV PATH $PATH:/usr/local/go/bin:/root/go/bin
 COPY --from=go-builder /go/bin /root/go/bin
 COPY --from=go-builder /go/src/github.com/YuheiNakasaka/sayhuuzoku/db/data.db /root/go/src/github.com/YuheiNakasaka/sayhuuzoku/db/data.db
+COPY --from=go-builder /go/src/github.com/YuheiNakasaka/sayhuuzoku/scraping/ /root/go/src/github.com/YuheiNakasaka/sayhuuzoku/scraping/
 RUN ln -s /root/go/src/github.com/YuheiNakasaka/sayhuuzoku/db /
 
 # Ruby

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,24 +1,37 @@
+# syntax = docker/dockerfile:1.0-experimental
 ## Go
-FROM golang:1.12-stretch as go-builder
+FROM ubuntu:19.04 as go-builder
 RUN apt update -qq
-RUN apt install -y -qq libmecab-dev
-RUN go get -u github.com/YuheiNakasaka/sayhuuzoku
-RUN go get -u github.com/tomnomnom/gron
-RUN go get -u github.com/ericchiang/pup
-RUN go get -u github.com/sugyan/ttyrec2gif
-RUN go get -u github.com/xztaityozx/owari
-RUN go get -u github.com/jiro4989/align
-RUN go get -u github.com/jiro4989/taishoku
-RUN go get -u github.com/jiro4989/textimg
-RUN CGO_LDFLAGS="`mecab-config --libs`" CGO_CFLAGS="-I`mecab-config --inc-dir`" go get -u github.com/ryuichiueda/ke2daira
+RUN apt install -y -qq curl git build-essential libmecab-dev
+
+RUN curl -sfSL --retry 3 https://dl.google.com/go/go1.12.linux-amd64.tar.gz -o go.tar.gz \
+    && tar xzf go.tar.gz -C /usr/local \
+    && rm go.tar.gz
+ENV GOPATH /root/go
+ENV PATH $PATH:/usr/local/go/bin:/root/go/bin
+
+RUN --mount=type=cache,target=/root/go/src \
+    --mount=type=cache,target=/root/.cache/go-build \
+    go get -u \
+      github.com/YuheiNakasaka/sayhuuzoku \
+      github.com/tomnomnom/gron \
+      github.com/ericchiang/pup \
+      github.com/sugyan/ttyrec2gif \
+      github.com/xztaityozx/owari \
+      github.com/jiro4989/align \
+      github.com/jiro4989/taishoku \
+      github.com/jiro4989/textimg
+RUN --mount=type=cache,target=/root/go/src \
+    --mount=type=cache,target=/root/.cache/go-build \
+    CGO_LDFLAGS="`mecab-config --libs`" CGO_CFLAGS="-I`mecab-config --inc-dir`" \
+    go get -u github.com/ryuichiueda/ke2daira
 
 ## Ruby
 FROM ubuntu:19.04 as ruby-builder
 RUN apt update -qq
-RUN apt install -y -qq curl
-RUN apt install -y -qq build-essential
-RUN apt install -y -qq ruby ruby-dev
-RUN gem install --quiet --no-ri --no-rdoc cureutils matsuya takarabako snacknomama rubipara marky_markov
+RUN apt install -y -qq curl git build-essential ruby-dev
+RUN --mount=type=cache,target=/root/.gem \
+    gem install --quiet --no-ri --no-rdoc cureutils matsuya takarabako snacknomama rubipara marky_markov
 RUN curl -sfSL --retry 3 https://raw.githubusercontent.com/hostilefork/whitespacers/master/ruby/whitespace.rb -o /usr/local/bin/whitespace
 RUN chmod +x /usr/local/bin/whitespace
 
@@ -26,142 +39,88 @@ RUN chmod +x /usr/local/bin/whitespace
 FROM ubuntu:19.04 as python-builder
 RUN apt update -qq
 RUN apt install -y -qq python-dev python-pip python-mecab python3-dev python3-pip
-RUN pip install --quiet sympy numpy scipy matplotlib pillow
-RUN pip3 install --quiet yq faker sympy numpy scipy matplotlib xonsh pillow asciinema
-RUN pip3 install --quiet "https://github.com/megagonlabs/ginza/releases/download/v1.0.1/ja_ginza_nopn-1.0.1.tgz"
+RUN --mount=type=cache,target=/root/.cache/pip \
+    pip install --progress-bar=off sympy numpy scipy matplotlib pillow
+RUN --mount=type=cache,target=/root/.cache/pip \
+    pip3 install --progress-bar=off yq faker sympy numpy scipy matplotlib xonsh pillow asciinema
+RUN --mount=type=cache,target=/root/.cache/pip \
+    pip3 install --progress-bar=off "https://github.com/megagonlabs/ginza/releases/download/v1.0.1/ja_ginza_nopn-1.0.1.tgz"
 
-# Node.js
+## Node.js
 FROM ubuntu:19.04 as nodejs-builder
 RUN apt update -qq
-RUN apt install -y -qq nodejs
-RUN apt install -y -qq npm
-RUN npm install -g --silent faker-cli chemi
+RUN apt install -y -qq nodejs npm
+RUN --mount=type=cache,target=/root/.npm \
+    npm install -g --silent faker-cli chemi
 
-# .NET
+## .NET
 FROM ubuntu:19.04 as dotnet-builder
-RUN apt update -qq
-RUN apt install -y -qq curl
-RUN apt install -y -qq git
-
-# install dotnet-core
-# 2019.05.05 時点で dotnet core がまだ ubuntu 19.04 に対応していないようなので、引き続き mono 利用; https://github.com/dotnet/core/issues/2657
-# RUN curl -sfSLO https://packages.microsoft.com/config/ubuntu/19.04/packages-microsoft-prod.deb
-# RUN dpkg -i packages-microsoft-prod.deb
-# RUN apt -y -qq install apt-transport-https
-# RUN apt update -qq
-# RUN apt install -y -qq dotnet-sdk-2.2
-
-# install mono-mcs
 ENV DEBIAN_FRONTEND noninteractive
-RUN apt install -y -qq mono-mcs
+RUN apt update -qq
+RUN apt install -y -qq curl git mono-mcs
 RUN git clone --depth 1 https://github.com/xztaityozx/noc.git
 RUN mcs noc/noc/noc/Program.cs
 
-# gawk 5.0
-FROM ubuntu:19.04 as gawk-builder
+## Rust
+FROM ubuntu:19.04 as rust-builder
 RUN apt update -qq
-RUN apt install -y -qq curl
-RUN apt install -y -qq build-essential
+RUN apt install -y -qq curl build-essential
+RUN curl -sfSL https://sh.rustup.rs | sh -s -- -y
+ENV PATH /root/.cargo/bin:$PATH
+RUN cargo install --git https://github.com/lotabout/rargs.git
 
+## General
+FROM ubuntu:19.04 as general-builder
+RUN apt update -qq
+RUN apt install -y -qq curl git build-essential
+
+# awk 5.0
 RUN curl -sfSLO https://ftp.gnu.org/gnu/gawk/gawk-5.0.0.tar.gz
 RUN tar xf gawk-5.0.0.tar.gz
 WORKDIR gawk-5.0.0
 RUN ./configure --program-suffix="-5.0.0"
 RUN make
 RUN make install
+WORKDIR /
+
+# Open-usp-Tukubai
+RUN git clone --depth 1 https://github.com/usp-engineers-community/Open-usp-Tukubai.git
+WORKDIR /Open-usp-Tukubai
+RUN make install
+WORKDIR /
 
 
 ## Runtime
 FROM ubuntu:19.04 as runtime
 
-# set lang, locale
+# Set environments
 ENV LANG ja_JP.UTF-8
 ENV TZ JST-9
 ENV PATH /usr/games:$PATH
-
-# apt install
 ENV DEBIAN_FRONTEND noninteractive
-RUN apt update -qq \
-    && apt-get install -y ruby \
-      ccze\
-      screen tmux\
-      ttyrec\
-      timidity abcmidi\
-      r-base\
-      boxes\
-      ash yash\
-      jq\
-      vim emacs\
-      nkf\
-      rs\
-      language-pack-ja\
-      pwgen\
-      bc\
-      perl\
-      toilet\
-      figlet\
-      haskell-platform\
-      git\
-      mecab mecab-ipadic mecab-ipadic-utf8\
-      wget curl npm\
-      bsdgames fortunes cowsay fortunes-off cowsay-off\
-      datamash\
-      gawk\
-      libxml2-utils\
-      zsh\
-      num-utils\
-      apache2-utils\
-      fish\
-      cowsay\
-      lolcat\
-      nyancat\
-      imagemagick\
-      moreutils\
-      strace\
-      whiptail\
-      pandoc\
-      postgresql-common\
-      postgresql-client-common\
-      icu-devtools\
-      tcsh\
-      libskk-dev\
-      libkkc-utils\
-      morsegen\
-      dc\
-      telnet\
-      python3-pip\
-      python-pip\
-      busybox\
-      parallel\
-      rename\
-      mt-st\
-      ffmpeg\
-      kakasi\
-      dateutils\
-      fonts-ipafont fonts-vlgothic\
-      inkscape gnuplot\
-      qrencode\
-      fonts-nanum fonts-symbola fonts-noto-color-emoji\
-      sl\
-      chromium-browser chromium-chromedriver nginx\
-      screenfetch\
-      mono-mcs mono-runtime\
-      firefox\
-      lua5.3 php7.2 php7.2-cli php7.2-common \
-      libedit-dev \
-    && apt clean \
-    && rm -rf /var/lib/apt/lists/
+
+# Enable keep apt cache
+RUN rm -f etc/apt/apt.conf.d/docker-clean; \
+    echo 'Binary::apt::APT::Keep-Downloaded-Packages "true";' > /etc/apt/apt.conf.d/keep-cache
+RUN --mount=type=cache,target=/var/cache/apt \
+    --mount=type=cache,target=/var/lib/apt \
+    apt update -qq && apt install -y -qq curl git unzip
+
+# egzact
+RUN curl -sfSLO --retry 3 https://git.io/egison-3.7.14.x86_64.deb \
+    && dpkg -i ./egison-3.7.14.x86_64.deb \
+    && rm ./egison-3.7.14.x86_64.deb
+
+# egison
+RUN curl -sfSLO --retry 3 https://git.io/egzact-1.3.1.deb \
+    && dpkg -i ./egzact-1.3.1.deb \
+    && rm ./egzact-1.3.1.deb
 
 # Julia
 RUN curl -sfSL --retry 3 https://julialang-s3.julialang.org/bin/linux/x64/1.1/julia-1.1.0-linux-x86_64.tar.gz -o julia.tar.gz \
     && tar xf julia.tar.gz \
     && rm julia.tar.gz \
     && ln -s $(realpath $(ls | grep -E "^julia") )/bin/julia /usr/local/bin/julia
-
-# Rust
-RUN curl -sfSL https://sh.rustup.rs | sh -s -- -y
-ENV PATH /root/.cargo/bin:$PATH
-RUN cargo install --git https://github.com/lotabout/rargs.git
 
 # J
 RUN curl -sfSL --retry 3 http://www.jsoftware.com/download/j807/install/j807_linux64_nonavx.tar.gz -o j.tar.gz \
@@ -198,11 +157,6 @@ RUN curl -sfSLO --retry 3 https://git.io/superunko.deb \
 
 # nameko.svg
 RUN curl -sfSLO https://gist.githubusercontent.com/KeenS/6194e6ef1a151c9ea82536d5850b8bc7/raw/85af9ec757308b8ca4effdf24221f642cb34703b/nameko.svg
-
-# tukubai
-RUN git clone --depth 1 https://github.com/usp-engineers-community/Open-usp-Tukubai.git \
-    && (cd Open-usp-Tukubai && make install) \
-    && rm -rf Open-usp-Tukubai
 
 # shellgei data
 RUN git clone --depth 1 https://github.com/ryuichiueda/ShellGeiData.git
@@ -246,15 +200,84 @@ RUN curl -sfSLO --retry 3 https://git.io/echo-meme.deb \
 RUN curl -sfSLO https://www.unicode.org/Public/UCD/latest/ucd/NormalizationTest.txt
 RUN curl -sfSLO https://www.unicode.org/Public/UCD/latest/ucd/NamesList.txt
 
+# apt
+RUN --mount=type=cache,target=/var/cache/apt \
+    --mount=type=cache,target=/var/lib/apt \
+    apt update -qq && apt install -y -qq \
+      ruby \
+      ccze \
+      screen tmux \
+      ttyrec \
+      timidity abcmidi \
+      r-base \
+      boxes \
+      ash yash \
+      jq \
+      vim emacs \
+      nkf \
+      rs \
+      language-pack-ja \
+      pwgen \
+      bc \
+      perl \
+      toilet \
+      figlet \
+      haskell-platform \
+      mecab mecab-ipadic mecab-ipadic-utf8 \
+      bsdgames fortunes cowsay fortunes-off cowsay-off \
+      datamash \
+      gawk \
+      libxml2-utils \
+      zsh \
+      num-utils \
+      apache2-utils \
+      fish \
+      lolcat \
+      nyancat \
+      imagemagick \
+      moreutils \
+      strace \
+      whiptail \
+      pandoc \
+      postgresql-common \
+      postgresql-client-common \
+      icu-devtools \
+      tcsh \
+      libskk-dev \
+      libkkc-utils \
+      morsegen \
+      dc \
+      telnet \
+      busybox \
+      parallel \
+      rename \
+      mt-st \
+      ffmpeg \
+      kakasi \
+      dateutils \
+      fonts-ipafont fonts-vlgothic \
+      inkscape gnuplot \
+      qrencode \
+      fonts-nanum fonts-symbola fonts-noto-color-emoji \
+      sl \
+      chromium-browser chromium-chromedriver nginx \
+      screenfetch \
+      mono-runtime \
+      firefox \
+      lua5.3 php7.2 php7.2-cli php7.2-common \
+      nodejs
+
 # Go
 RUN curl -sfSL --retry 3 https://dl.google.com/go/go1.12.linux-amd64.tar.gz -o go.tar.gz \
     && tar xzf go.tar.gz -C /usr/local \
     && rm go.tar.gz
 ENV GOPATH /root/go
 ENV PATH $PATH:/usr/local/go/bin:/root/go/bin
-COPY --from=go-builder /go/bin /root/go/bin
-COPY --from=go-builder /go/src/github.com/YuheiNakasaka/sayhuuzoku/db/data.db /root/go/src/github.com/YuheiNakasaka/sayhuuzoku/db/data.db
-COPY --from=go-builder /go/src/github.com/YuheiNakasaka/sayhuuzoku/scraping/ /root/go/src/github.com/YuheiNakasaka/sayhuuzoku/scraping/
+COPY --from=go-builder /root/go/bin /root/go/bin
+RUN mkdir -p /root/go/src/github.com/YuheiNakasaka/sayhuuzoku/db/
+RUN curl -sfSL https://raw.githubusercontent.com/YuheiNakasaka/sayhuuzoku/master/db/data.db -o /root/go/src/github.com/YuheiNakasaka/sayhuuzoku/db/data.db
+RUN mkdir -p /root/go/src/github.com/YuheiNakasaka/sayhuuzoku/scraping/
+RUN curl -sfSL https://raw.githubusercontent.com/YuheiNakasaka/sayhuuzoku/master/scraping/shoplist.txt -o /root/go/src/github.com/YuheiNakasaka/sayhuuzoku/scraping/shoplist.txt
 RUN ln -s /root/go/src/github.com/YuheiNakasaka/sayhuuzoku/db /
 
 # Ruby
@@ -267,16 +290,6 @@ COPY --from=python-builder /usr/local/bin /usr/local/bin
 COPY --from=python-builder /usr/local/lib/python2.7 /usr/local/lib/python2.7
 COPY --from=python-builder /usr/local/lib/python3.7 /usr/local/lib/python3.7
 
-# egzact
-RUN curl -sfSLO --retry 3 https://git.io/egison-3.7.14.x86_64.deb \
-    && dpkg -i ./egison-3.7.14.x86_64.deb \
-    && rm ./egison-3.7.14.x86_64.deb
-
-# egison
-RUN curl -sfSLO --retry 3 https://git.io/egzact-1.3.1.deb \
-    && dpkg -i ./egzact-1.3.1.deb \
-    && rm ./egzact-1.3.1.deb
-
 # Node.js
 COPY --from=nodejs-builder /usr/local/bin /usr/local/bin
 COPY --from=nodejs-builder /usr/local/lib/node_modules /usr/local/lib/node_modules
@@ -284,7 +297,12 @@ COPY --from=nodejs-builder /usr/local/lib/node_modules /usr/local/lib/node_modul
 # .NET
 COPY --from=dotnet-builder /noc/noc/noc/Program.exe /noc
 
-# gawk 5.0
-COPY --from=gawk-builder /usr/local /usr/local
+# Rust
+COPY --from=rust-builder /root/.cargo /root/.cargo
+RUN curl -sfSL https://sh.rustup.rs | sh -s -- -y
+ENV PATH /root/.cargo/bin:$PATH
+
+# gawk 5.0 / Open-usp-Tukubai
+COPY --from=general-builder /usr/local /usr/local
 
 CMD /bin/bash

--- a/README.md
+++ b/README.md
@@ -1,0 +1,31 @@
+# ShellGeiBot
+
+## Build Docker image
+
+```sh
+$ ./build.bash
+```
+
+## Test Docker image
+
+- Uses [Bats](https://github.com/sstephenson/bats) for test docker image.
+
+### Installation
+
+- Linux (with APT)
+
+```sh
+$ sudo apt install bats
+```
+
+- macOS (with Homebrew)
+
+```sh
+$ brew install bats
+```
+
+### Run
+
+```sh
+$ bats docker_image.bats
+```

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ## Build Docker image
 
 ```sh
-$ ./build.bash
+$ ./build.bash shellgeibot:latest
 ```
 
 ## Test Docker image
@@ -27,5 +27,5 @@ $ brew install bats
 ### Run
 
 ```sh
-$ bats docker_image.bats
+$ DOCKER_IMAGE=shellgeibot:latest bats docker_image.bats
 ```

--- a/build.bash
+++ b/build.bash
@@ -1,2 +1,3 @@
 #!/bin/bash
+DOCKER_BUILDKIT=1 \
 docker build  . -t $@

--- a/docker_image.bats
+++ b/docker_image.bats
@@ -142,20 +142,20 @@
   [[ "$output" =~ "git version" ]]
 }
 
-# @test "build-essential" {
-#   run docker container run --rm ${DOCKER_IMAGE} gcc --version
-#   [[ "${lines[0]}" =~ gcc ]]
-# }
+@test "build-essential" {
+  run docker container run --rm ${DOCKER_IMAGE} gcc --version
+  [[ "${lines[0]}" =~ gcc ]]
+}
 
 @test "mecab" {
   run docker container run --rm ${DOCKER_IMAGE} bash -c "echo シェル芸 | mecab -Owakati"
   [ "$output" = "シェル 芸 " ]
 }
 
-@test "wget" {
-  run docker container run --rm ${DOCKER_IMAGE} bash -c "echo シェル芸 > index.txt && python3 -m http.server & sleep 0.5 && wget -q http://localhost:8000/index.txt -O -"
-  [ "$output" = "シェル芸" ]
-}
+# @test "wget" {
+#   run docker container run --rm ${DOCKER_IMAGE} bash -c "echo シェル芸 > index.txt && python3 -m http.server & sleep 0.5 && wget -q http://localhost:8000/index.txt -O -"
+#   [ "$output" = "シェル芸" ]
+# }
 
 @test "curl" {
   run docker container run --rm ${DOCKER_IMAGE} bash -c "echo シェル芸 > index.txt && python3 -m http.server & sleep 0.5 && curl -s http://localhost:8000/index.txt"
@@ -163,10 +163,10 @@
   [ "$output" = "シェル芸" ]
 }
 
-@test "npm" {
-  run docker container run --rm ${DOCKER_IMAGE} which npm
-  [ "$output" = "/usr/bin/npm" ]
-}
+# @test "npm" {
+#   run docker container run --rm ${DOCKER_IMAGE} which npm
+#   [ "$output" = "/usr/bin/npm" ]
+# }
 
 @test "bsdgames" {
   run docker container run --rm ${DOCKER_IMAGE} bash -c "echo '... .... . .-.. .-.. --. . ..  ...-.-' | morse -d"

--- a/docker_image.bats
+++ b/docker_image.bats
@@ -2,6 +2,8 @@
 
 @test "Ruby" {
   run docker container run --rm ${DOCKER_IMAGE} bash -c "echo シェル芸 | ruby -nle 'puts \$_'"
+  echo "status: ${status}"
+  echo "output: ${output}"
   [ "$output" = "シェル芸" ]
 }
 
@@ -140,10 +142,10 @@
   [[ "$output" =~ "git version" ]]
 }
 
-@test "build-essential" {
-  run docker container run --rm ${DOCKER_IMAGE} gcc --version
-  [[ "${lines[0]}" =~ gcc ]]
-}
+# @test "build-essential" {
+#   run docker container run --rm ${DOCKER_IMAGE} gcc --version
+#   [[ "${lines[0]}" =~ gcc ]]
+# }
 
 @test "mecab" {
   run docker container run --rm ${DOCKER_IMAGE} bash -c "echo シェル芸 | mecab -Owakati"
@@ -658,6 +660,12 @@
 @test "rust" {
   run docker container run --rm ${DOCKER_IMAGE} rustc --help
   [ "${lines[0]}" = 'Usage: rustc [OPTIONS] INPUT' ]
+}
+
+@test "rargs" {
+  run docker container run --rm ${DOCKER_IMAGE} rargs --help
+  [[ "${lines[0]}" =~ "Rargs " ]]
+  [ "${lines[2]}" = 'Xargs with pattern matching' ]
 }
 
 @test "ShellGeiData" {

--- a/docker_image.bats
+++ b/docker_image.bats
@@ -1,0 +1,736 @@
+#!/usr/bin/env bats
+
+@test "Ruby" {
+  run docker container run --rm ${DOCKER_IMAGE} bash -c "echo シェル芸 | ruby -nle 'puts \$_'"
+  [ "$output" = "シェル芸" ]
+}
+
+@test "ccze" {
+  run docker container run --rm ${DOCKER_IMAGE} bash -c "echo シェル芸 | ccze -A"
+  [[ "$output" =~ シェル芸 ]]
+}
+
+@test "screen" {
+  run docker container run --rm ${DOCKER_IMAGE} bash -c "screen -v"
+  [[ "$output" =~ Screen ]]
+}
+
+@test "tmux" {
+  run docker container run --rm ${DOCKER_IMAGE} tmux -c "echo シェル芸"
+  [ "$output" = "シェル芸" ]
+}
+
+@test "ttyrec" {
+  run docker container run --rm ${DOCKER_IMAGE} bash -c "ttyrec -h"
+  [[ "$output" =~ ttyrec ]]
+}
+
+@test "TiMidity++" {
+  run docker container run --rm ${DOCKER_IMAGE} bash -c "timidity -v"
+  [[ "$output" =~ TiMidity\+\+ ]]
+}
+
+@test "abcMIDI" {
+  run docker container run --rm ${DOCKER_IMAGE} bash -c "abc2midi -ver"
+  [[ "$output" =~ abc2midi ]]
+}
+
+@test "R" {
+  run docker container run --rm ${DOCKER_IMAGE} bash -c "echo シェル芸 | R -q -e 'cat(readLines(\"stdin\"))'"
+  [[ "$output" =~ シェル芸 ]]
+}
+
+@test "boxes" {
+  run docker container run --rm ${DOCKER_IMAGE} bash -c "echo シェル芸 | boxes"
+  [[ "$output" =~ \/\*\ シェル芸\ \*\/ ]]
+}
+
+# /bin/ash は /bin/dash へのエイリアス, /usr/bin/ash は /usr/bin/dash へのエイリアスで、両方とも同じ
+# apt install ash ではエイリアスが作成されるのみ
+@test "ash" {
+  run docker container run --rm ${DOCKER_IMAGE} ash -c "echo シェル芸"
+  [ "$output" = シェル芸 ]
+}
+
+@test "yash" {
+  run docker container run --rm ${DOCKER_IMAGE} yash -c "echo シェル芸"
+  [ "$output" = シェル芸 ]
+}
+
+@test "jq" {
+  run docker container run --rm ${DOCKER_IMAGE} bash -c "echo シェル芸 | jq -Rr '.'"
+  [ "$output" = シェル芸 ]
+}
+
+@test "Vim" {
+  run docker container run --rm ${DOCKER_IMAGE} bash -c "echo シェル芸 | vim -es +%p +q! /dev/stdin"
+  [ "$output" = シェル芸 ]
+}
+
+@test "Emacs" {
+  run docker container run --rm ${DOCKER_IMAGE} bash -c "echo シェル芸 | emacs -Q --batch --insert /dev/stdin --eval='(princ (buffer-string))'"
+  [ "$output" = シェル芸 ]
+}
+
+@test "Python2" {
+  run docker container run --rm ${DOCKER_IMAGE} bash -c "echo シェル芸 | python -c 'import sys;print sys.stdin.readline().rstrip()'"
+  [ "$output" = シェル芸 ]
+}
+
+@test "Python3" {
+  run docker container run --rm ${DOCKER_IMAGE} bash -c "echo シェル芸 | python3 -c 'import sys;print(sys.stdin.readline().rstrip())'"
+  [ "$output" = シェル芸 ]
+}
+
+@test "nkf" {
+  run docker container run --rm ${DOCKER_IMAGE} bash -c "echo シェル芸 | nkf"
+  [ "$output" = シェル芸 ]
+}
+
+@test "rs" {
+  run docker container run --rm ${DOCKER_IMAGE} bash -c "echo シェル芸 | grep -o . | rs -T | tr -d ' '"
+  [ "$output" = シェル芸 ]
+}
+
+@test "pwgen" {
+  run docker container run --rm ${DOCKER_IMAGE} bash -c "pwgen -h"
+  [ $status -eq 1 ]
+  [[ "$output" =~ pwgen ]]
+}
+
+@test "bc" {
+  run docker container run --rm ${DOCKER_IMAGE} bash -c "echo 'print \"シェル芸\n\"' | bc"
+  [ "$output" = "シェル芸" ]
+}
+
+@test "Perl" {
+  run docker container run --rm ${DOCKER_IMAGE} bash -c "echo シェル芸 | perl -nle 'print \$_'"
+  [ "$output" = "シェル芸" ]
+}
+
+@test "toilet" {
+  run docker container run --rm ${DOCKER_IMAGE} bash -c "echo シェル芸 | toilet"
+  [ "${lines[0]}" = '                                          ' ]
+  [ "${lines[1]}" = '   ""m                        m  "m       ' ]
+  [ "${lines[2]}" = '  mm                           #  #       ' ]
+  [ "${lines[3]}" = '    "    m"      mmm""         #  #   #   ' ]
+  [ "${lines[4]}" = '       m"          #mm        m"  # m"    ' ]
+  [ "${lines[5]}" = '  "mm""         """"  "      m"   #"      ' ]
+  [ "${lines[6]}" = '                                          ' ]
+  [ "${lines[7]}" = '                                          ' ]
+}
+
+@test "figlet" {
+  run docker container run --rm ${DOCKER_IMAGE} bash -c "echo ShellGei | figlet"
+  echo "lines[0]: '${lines[0]}'"
+  [ "${lines[0]}" = " ____  _          _ _  ____      _ " ]
+  [ "${lines[1]}" = "/ ___|| |__   ___| | |/ ___| ___(_)" ]
+  [ "${lines[2]}" = "\___ \| '_ \ / _ \ | | |  _ / _ \ |" ]
+  [ "${lines[3]}" = " ___) | | | |  __/ | | |_| |  __/ |" ]
+  [ "${lines[4]}" = "|____/|_| |_|\___|_|_|\____|\___|_|" ]
+}
+
+@test "Haskell" {
+  run docker container run --rm ${DOCKER_IMAGE} ghc -e 'putStrLn "シェル芸"'
+  [ "$output" = "シェル芸" ]
+}
+
+@test "Git" {
+  run docker container run --rm ${DOCKER_IMAGE} git version
+  [[ "$output" =~ "git version" ]]
+}
+
+@test "build-essential" {
+  run docker container run --rm ${DOCKER_IMAGE} gcc --version
+  [[ "${lines[0]}" =~ gcc ]]
+}
+
+@test "mecab" {
+  run docker container run --rm ${DOCKER_IMAGE} bash -c "echo シェル芸 | mecab -Owakati"
+  [ "$output" = "シェル 芸 " ]
+}
+
+@test "wget" {
+  run docker container run --rm ${DOCKER_IMAGE} bash -c "echo シェル芸 > index.txt && python3 -m http.server & sleep 0.5 && wget -q http://localhost:8000/index.txt -O -"
+  [ "$output" = "シェル芸" ]
+}
+
+@test "curl" {
+  run docker container run --rm ${DOCKER_IMAGE} bash -c "echo シェル芸 > index.txt && python3 -m http.server & sleep 0.5 && curl -s http://localhost:8000/index.txt"
+  echo "output: '$output'"
+  [ "$output" = "シェル芸" ]
+}
+
+@test "npm" {
+  run docker container run --rm ${DOCKER_IMAGE} which npm
+  [ "$output" = "/usr/bin/npm" ]
+}
+
+@test "bsdgames" {
+  run docker container run --rm ${DOCKER_IMAGE} bash -c "echo '... .... . .-.. .-.. --. . ..  ...-.-' | morse -d"
+  [ "$output" = "SHELLGEI" ]
+}
+
+@test "fortune" {
+  run docker container run --rm ${DOCKER_IMAGE} fortune
+  [ $status -eq 0 ]
+}
+
+# 2回指定されている
+@test "cowsay" {
+  run docker container run --rm ${DOCKER_IMAGE} cowsay シェル芸
+  [ "${lines[0]}" = ' __________' ]
+  [ "${lines[1]}" = '< シェル芸 >' ]
+  [ "${lines[2]}" = ' ----------' ]
+  [ "${lines[3]}" = '        \   ^__^' ]
+  [ "${lines[4]}" = '         \  (oo)\_______' ]
+  [ "${lines[5]}" = '            (__)\       )\/\' ]
+  [ "${lines[6]}" = '                ||----w |' ]
+  [ "${lines[7]}" = '                ||     ||' ]
+}
+
+@test "datamash" {
+  run docker container run --rm ${DOCKER_IMAGE} datamash --version
+  [[ "${lines[0]}" =~ "datamash (GNU datamash)" ]]
+}
+
+@test "gawk" {
+  run docker container run --rm ${DOCKER_IMAGE} bash -c "echo シェル芸 | gawk '{print \$0}'"
+  [ "$output" = "シェル芸" ]
+}
+
+@test "libxml2-utils" {
+  run docker container run --rm ${DOCKER_IMAGE} bash -c "echo '<?xml version=\"1.0\"?><e>ShellGei</e>' | xmllint --xpath '/e/text()' -"
+  [ "$output" = "ShellGei" ]
+}
+
+@test "zsh" {
+  run docker container run --rm ${DOCKER_IMAGE} zsh -c "echo シェル芸"
+  [ "$output" = "シェル芸" ]
+}
+
+@test "num-utils" {
+  run docker container run --rm ${DOCKER_IMAGE} numaverage -h
+  [ "${lines[1]}" = "numaverage : A program for finding the average of numbers." ]
+}
+
+# 不要では?
+@test "apache2-utils" {
+  run docker container run --rm ${DOCKER_IMAGE} ab -V
+  [[ "${lines[0]}" =~ "ApacheBench" ]]
+}
+
+@test "fish" {
+  run docker container run --rm ${DOCKER_IMAGE} fish -c "echo シェル芸"
+  [ "$output" = "シェル芸" ]
+}
+
+@test "lolcat" {
+  run docker container run --rm ${DOCKER_IMAGE} which lolcat
+  [ "$output" = "/usr/games/lolcat" ]
+}
+
+@test "nyancat" {
+  run docker container run --rm ${DOCKER_IMAGE} nyancat -h
+  [ "${lines[0]}" = "Terminal Nyancat" ]
+}
+
+@test "ImageMagick" {
+  run docker container run --rm ${DOCKER_IMAGE} convert -version
+  [[ "${lines[0]}" =~ "Version: ImageMagick" ]]
+}
+
+@test "moreutils" {
+  run docker container run --rm ${DOCKER_IMAGE} which pee
+  [ "$output" = "/usr/bin/pee" ]
+}
+
+# strace は docker 上で実行する場合、--cap-add=SYS_PTRACE と --security-opt="seccomp=unconfined" が必要になるため、不要では
+@test "strace" {
+  run docker container run --rm ${DOCKER_IMAGE} strace -V
+  [[ "${lines[0]}" =~ "strace -- version" ]]
+}
+
+@test "whiptail" {
+  run docker container run --rm ${DOCKER_IMAGE} whiptail -v
+  [[ "$output" =~ "whiptail" ]]
+}
+
+@test "pandoc" {
+  run docker container run --rm ${DOCKER_IMAGE} pandoc -v
+  [[ "${lines[0]}" =~ "pandoc" ]]
+}
+
+@test "postgresql" {
+  run docker container run --rm ${DOCKER_IMAGE} which psql
+  [ "$output" = "/usr/bin/psql" ]
+}
+
+@test "uconv" {
+  run docker container run --rm ${DOCKER_IMAGE} bash -c "echo 30b730a730eb82b8 | xxd -p -r | uconv -f utf-16be -t utf-8"
+  [ "$output" = "シェル芸" ]
+}
+
+@test "tcsh" {
+  run docker container run --rm ${DOCKER_IMAGE} tcsh -c "echo シェル芸"
+  [ "$output" = "シェル芸" ]
+}
+
+# 不要?
+@test "libskk-dev" {
+  run docker container run --rm ${DOCKER_IMAGE} stat /usr/lib/x86_64-linux-gnu/libskk.so
+  [ "${lines[0]}" = "  File: /usr/lib/x86_64-linux-gnu/libskk.so -> libskk.so.0.0.0" ]
+}
+
+@test "kkc" {
+  run docker container run --rm ${DOCKER_IMAGE} kkc help
+  [ "${lines[1]}" = "  kkc help コマンド" ]
+}
+
+@test "morsegen" {
+  run docker container run --rm ${DOCKER_IMAGE} morsegen
+  [ $status -eq 1 ]
+  [[ "${lines[1]}" =~ "Morse Generator." ]]
+}
+
+@test "dc" {
+  run docker container run --rm ${DOCKER_IMAGE} dc -V
+  [[ "${lines[0]}" =~ "dc" ]]
+}
+
+@test "telnet" {
+  run docker container run --rm ${DOCKER_IMAGE} which telnet
+  [ "$output" = "/usr/bin/telnet" ]
+}
+
+@test "busybox" {
+  run docker container run --rm ${DOCKER_IMAGE} /bin/busybox echo "シェル芸"
+  [ "$output" = "シェル芸" ]
+}
+
+@test "parallel" {
+  run docker container run --rm ${DOCKER_IMAGE} parallel --version
+  [[ "${lines[0]}" =~ "GNU parallel" ]]
+}
+
+@test "rename" {
+  run docker container run --rm ${DOCKER_IMAGE} rename -V
+  [[ "${lines[0]}" =~ "/usr/bin/rename" ]]
+}
+
+@test "mt" {
+  run docker container run --rm ${DOCKER_IMAGE} mt -v
+  [[ "${lines[0]}" =~ "mt-st" ]]
+}
+
+@test "ffmpeg" {
+  run docker container run --rm ${DOCKER_IMAGE} ffmpeg -version
+  [[ "${lines[0]}" =~ "ffmpeg version" ]]
+}
+
+@test "kakasi" {
+  run docker container run --rm ${DOCKER_IMAGE} bash -c "echo シェル芸 | nkf -e | kakasi -JH | nkf -w"
+  [ "$output" = "シェルげい" ]
+}
+
+@test "dateutils" {
+  run docker container run --rm ${DOCKER_IMAGE} /usr/bin/dateutils.dtest -V
+  [[ "$output" =~ "datetest" ]]
+}
+
+@test "fonts-ipafont" {
+  run docker container run --rm ${DOCKER_IMAGE} bash -c "fc-list | grep ipa | wc -l"
+  [ $output -ge 4 ]
+}
+
+@test "fonts-vlgothic" {
+  run docker container run --rm ${DOCKER_IMAGE} bash -c "fc-list | grep vlgothic | wc -l"
+  [ $output -ge 2 ]
+}
+
+@test "inkscape" {
+  run docker container run --rm ${DOCKER_IMAGE} inkscape --version
+  [[ "$output" =~ "Inkscape" ]]
+}
+
+@test "gnuplot" {
+  run docker container run --rm ${DOCKER_IMAGE} gnuplot -V
+  [[ "$output" =~ "gnuplot" ]]
+}
+
+@test "qrencode" {
+  run docker container run --rm ${DOCKER_IMAGE} qrencode -V
+  [[ "${lines[0]}" =~ "qrencode version" ]]
+}
+
+@test "fonts-nanum" {
+  run docker container run --rm ${DOCKER_IMAGE} bash -c "fc-list | grep nanum | wc -l"
+  [ $output -ge 10 ]
+}
+
+@test "fonts-symbola" {
+  run docker container run --rm ${DOCKER_IMAGE} bash -c "fc-list | grep Symbola | wc -l"
+  [ $output -ge 1 ]
+}
+
+@test "fonts-noto-color-emoji" {
+  run docker container run --rm ${DOCKER_IMAGE} bash -c "fc-list | grep NotoColorEmoji | wc -l"
+  [ $output -ge 1 ]
+}
+
+@test "sl" {
+  run docker container run --rm ${DOCKER_IMAGE} which sl
+  [ "$output" = /usr/games/sl ]
+}
+
+@test "chromium" {
+  run docker container run --rm ${DOCKER_IMAGE} chromium-browser --version
+  [[ "$output" =~ "Chromium" ]]
+}
+
+@test "nginx" {
+  run docker container run --rm ${DOCKER_IMAGE} nginx -v
+  [[ "$output" =~ "nginx version:" ]]
+}
+
+@test "screenfetch" {
+  run docker container run --rm ${DOCKER_IMAGE} bash -c "screenfetch -V | sed $'s/\033\[[0-9]m//g'"
+  [[ "${lines[0]}" =~ "screenFetch - Version" ]]
+}
+
+@test "mono-runtime" {
+  run docker container run --rm ${DOCKER_IMAGE} mono --version
+  [[ "${lines[0]}" =~ "Mono JIT compiler version" ]]
+}
+
+@test "firefox" {
+  run docker container run --rm ${DOCKER_IMAGE} firefox --version
+  [[ "$output" =~ "Mozilla Firefox" ]]
+}
+
+@test "lua" {
+  run docker container run --rm ${DOCKER_IMAGE} lua -e 'print("シェル芸")'
+  [ "$output" = "シェル芸" ]
+}
+
+@test "php" {
+  run docker container run --rm ${DOCKER_IMAGE} php -r 'echo "シェル芸\n";'
+  [ "$output" = "シェル芸" ]
+}
+
+@test "cureutils" {
+  run docker container run --rm ${DOCKER_IMAGE} bash -c "cure girls | head -1"
+  [ "$output" = "美墨なぎさ" ]
+}
+
+@test "matsuya" {
+  run docker container run --rm ${DOCKER_IMAGE} matsuya
+  [ $status -eq 0 ]
+}
+
+@test "takarabako" {
+  run docker container run --rm ${DOCKER_IMAGE} takarabako
+  [ $status -eq 0 ]
+}
+
+@test "snacknomama" {
+  run docker container run --rm ${DOCKER_IMAGE} snacknomama
+  [ $status -eq 0 ]
+}
+
+@test "rubipara" {
+  run docker container run --rm ${DOCKER_IMAGE} rubipara kashikoma
+  [ "${lines[0]}"  = '                 ／^v ＼'                                      ]
+  [ "${lines[1]}"  = '               _{ / |-.(`_￣}__'                               ]
+  [ "${lines[2]}"  = "        _人_  〃⌒ ﾝ'八{   ｀ノト､\`ヽ"                           ]
+  [ "${lines[3]}"  = '        `Ｙ´  {l／ / /    / Ｖﾉ } ﾉ    (     Kashikoma!     )'  ]
+  [ "${lines[4]}"  = '          ,-ｍ彡-ｧ Ｌﾒ､_彡ｲ } }＜く   O'                         ]
+  [ "${lines[5]}"  = "         / _Uヽ⊂ﾆ{J:}  '⌒Ｖ  {  l| o"                          ]
+  [ "${lines[6]}"  = "       ／  r‐='V(｢\`¨,  r=≪,/ { .ﾉﾉ"                           ]
+  [ "${lines[7]}"  = '      /   /_xヘ 人 丶-  _彡ｲ ∧〉'                               ]
+  [ "${lines[8]}"  = '      (  ノ¨ﾌ’  ｀^> ‐ｧｧ ＜¨ﾌｲ'                                 ]
+  [ "${lines[9]}"  = "       --＝〉_丶/ﾉ { 彡' '|           Everyone loves Pripara!"  ]
+  [ "${lines[10]}" = "           ^  '7^ O〉|’ ,丿"                                   ]
+  [ "${lines[11]}" = '＿＿＿＿ ___ __ _{’O 乙,_r[_ __ ___ __________________________' ]
+}
+
+@test "marky_markov" {
+  run docker container run --rm ${DOCKER_IMAGE} marky_markov -h
+  [ "${lines[0]}" = 'Usage: marky_markov COMMAND [OPTIONS]' ]
+}
+
+@test "yq" {
+  run docker container run --rm ${DOCKER_IMAGE} yq --version
+  [[ "${lines[0]}" =~ "yq" ]]
+}
+
+@test "faker" {
+  run docker container run --rm ${DOCKER_IMAGE} faker name
+  [ $status -eq 0 ]
+}
+
+@test "sympy-python3" {
+  run docker container run --rm ${DOCKER_IMAGE} python3 -c 'import sympy; print(sympy.__name__)'
+  [ "$output" = "sympy" ]
+}
+
+@test "sympy" {
+  run docker container run --rm ${DOCKER_IMAGE} python -c 'import sympy; print sympy.__name__'
+  [ "$output" = "sympy" ]
+}
+
+@test "numpy-python3" {
+  run docker container run --rm ${DOCKER_IMAGE} python3 -c 'import numpy; print(numpy.__name__)'
+  [ "$output" = "numpy" ]
+}
+
+@test "numpy" {
+  run docker container run --rm ${DOCKER_IMAGE} python -c 'import numpy; print numpy.__name__'
+  [ "$output" = "numpy" ]
+}
+
+@test "scipy-python3" {
+  run docker container run --rm ${DOCKER_IMAGE} python3 -c 'import scipy; print(scipy.__name__)'
+  [ "$output" = "scipy" ]
+}
+
+@test "scipy" {
+  run docker container run --rm ${DOCKER_IMAGE} python -c 'import scipy; print scipy.__name__'
+  [ "$output" = "scipy" ]
+}
+
+@test "matplotlib-python3" {
+  run docker container run --rm ${DOCKER_IMAGE} python3 -c 'import matplotlib; print(matplotlib.__name__)'
+  [ "$output" = "matplotlib" ]
+}
+
+@test "matplotlib" {
+  run docker container run --rm ${DOCKER_IMAGE} python -c 'import matplotlib; print matplotlib.__name__'
+  [ "$output" = "matplotlib" ]
+}
+
+@test "xonsh" {
+  run docker container run --rm ${DOCKER_IMAGE} xonsh -c 'echo シェル芸'
+  [ "$output" = "シェル芸" ]
+}
+
+@test "pillow-python3" {
+  run docker container run --rm ${DOCKER_IMAGE} python3 -c 'import PIL; print(PIL.__name__)'
+  [ "$output" = "PIL" ]
+}
+
+@test "pillow" {
+  run docker container run --rm ${DOCKER_IMAGE} python -c 'import PIL; print PIL.__name__'
+  [ "$output" = "PIL" ]
+}
+
+@test "asciinema" {
+  run docker container run --rm ${DOCKER_IMAGE} asciinema --version
+  [[ "${lines[0]}" =~ "asciinema " ]]
+}
+
+@test "GiNZA" {
+  run docker container run --rm ${DOCKER_IMAGE} bash -c "echo シェル芸 | python3 -m spacy.lang.ja_ginza.cli 2>/dev/null | awk 'NR>=2{print \$3}'"
+  [ "${lines[0]}" = 'シェル' ]
+  [ "${lines[1]}" = '芸' ]
+}
+
+@test "egison" {
+  run docker container run --rm ${DOCKER_IMAGE} egison --help
+  echo "'${lines[0]}'"
+  [ "${lines[0]}" = 'Usage: egison [options]' ]
+}
+
+@test "egzact" {
+  run docker container run --rm ${DOCKER_IMAGE} bash -c "echo シェル芸 | dupl 2"
+  [ "${lines[0]}" = 'シェル芸' ]
+  [ "${lines[1]}" = 'シェル芸' ]
+}
+
+@test "faker-cli" {
+  run docker container run --rm ${DOCKER_IMAGE} faker-cli --help
+  [ "${lines[0]}" = 'Usage: faker-cli [option]' ]
+}
+
+@test "chemi" {
+  run docker container run --rm ${DOCKER_IMAGE} chemi -s H
+  [ "${lines[2]}" = 'element     : Hydrogen' ]
+}
+
+@test "home-commands" {
+  run docker container run --rm ${DOCKER_IMAGE} echo-sd シェル芸
+  [ "${lines[0]}" = '＿人人人人人人＿' ]
+  [ "${lines[1]}" = '＞　シェル芸　＜' ]
+  [ "${lines[2]}" = '￣Y^Y^Y^Y^Y^Y^￣' ]
+}
+
+@test "J" {
+  run docker container run --rm ${DOCKER_IMAGE} bash -c "echo \"'シェル芸'\" | jconsole"
+  echo "'${lines[0]}'"
+  [ "${lines[0]}" = '   シェル芸' ]
+}
+
+@test "trdsql" {
+  run docker container run --rm ${DOCKER_IMAGE} trdsql -help
+  [ "${lines[0]}" = 'Usage: trdsql [OPTIONS] [SQL(SELECT...)]' ]
+}
+
+@test "openjdk11" {
+  run docker container run --rm ${DOCKER_IMAGE} javac -version
+  [[ "${output}" =~ "javac " ]]
+}
+
+@test "super unko" {
+  run docker container run --rm ${DOCKER_IMAGE} unko.tower 2
+  [ "${lines[0]}" = '　　　　人' ]
+  [ "${lines[1]}" = '　　（　　　）' ]
+  [ "${lines[2]}" = '　（　　　　　）' ]
+}
+
+@test "nameko.svg" {
+  run docker container run --rm ${DOCKER_IMAGE} file nameko.svg
+  [ "$output" = 'nameko.svg: SVG Scalable Vector Graphics image' ]
+}
+
+@test "sayhuuzoku" {
+  run docker container run --rm ${DOCKER_IMAGE} sayhuuzoku g
+  [ $status -eq 0 ]
+}
+
+@test "sayhoozoku shoplist" {
+  run docker container run --rm ${DOCKER_IMAGE} stat "/root/go/src/github.com/YuheiNakasaka/sayhuuzoku/scraping/shoplist.txt"
+  [ "${lines[0]}" = '  File: /root/go/src/github.com/YuheiNakasaka/sayhuuzoku/scraping/shoplist.txt' ]
+}
+
+@test "gron" {
+  run docker container run --rm ${DOCKER_IMAGE} bash -c "echo '{\"s\":\"シェル芸\"}' | gron -m"
+  [ "${lines[1]}" = 'json.s = "シェル芸";' ]
+}
+
+@test "pup" {
+  run docker container run --rm ${DOCKER_IMAGE} pup --help
+  [ "${lines[1]}" = '    pup [flags] [selectors] [optional display function]' ]
+}
+
+@test "ttyrec2gif" {
+  run docker container run --rm ${DOCKER_IMAGE} ttyrec2gif -help
+  [ "${lines[0]}" = 'Usage of ttyrec2gif:' ]
+}
+
+@test "owari" {
+  run docker container run --rm ${DOCKER_IMAGE} owari -w 20
+  [ "${lines[0]}" = '        糸冬' ]
+}
+
+@test "align" {
+  run docker container run --rm ${DOCKER_IMAGE} bash -c "yes シェル芸 | head -4 | awk '{print substr(\$1,1,NR)}' | align center"
+  [ "${lines[0]}" = '   シ   ' ]
+  [ "${lines[1]}" = '  シェ  ' ]
+  [ "${lines[2]}" = ' シェル ' ]
+  [ "${lines[3]}" = 'シェル芸' ]
+}
+
+@test "taishoku" {
+  run docker container run --rm ${DOCKER_IMAGE} taishoku
+  [ "${lines[0]}" = '　　　代株　　　　二退こ　　　　　　' ]
+}
+
+@test "textimg" {
+  run docker container run --rm ${DOCKER_IMAGE} textimg --version
+  [[ "$output" =~ "textimg version " ]]
+}
+
+@test "whitespace" {
+  run docker container run --rm ${DOCKER_IMAGE} which whitespace
+  [ "$output" = '/usr/local/bin/whitespace' ]
+}
+
+@test "Open usp Tukubai" {
+  run docker container run --rm ${DOCKER_IMAGE} bash -c "echo シェル芸 | grep -o . | tateyoko"
+  [ "$output" = 'シ ェ ル 芸' ]
+}
+
+@test "julia" {
+  run docker container run --rm ${DOCKER_IMAGE} julia -e 'println("シェル芸")'
+  [ "$output" = 'シェル芸' ]
+}
+
+@test "rust" {
+  run docker container run --rm ${DOCKER_IMAGE} rustc --help
+  [ "${lines[0]}" = 'Usage: rustc [OPTIONS] INPUT' ]
+}
+
+@test "ShellGeiData" {
+  run docker container run --rm ${DOCKER_IMAGE} stat /ShellGeiData/README.md
+  [ "${lines[0]}" = '  File: /ShellGeiData/README.md' ]
+}
+
+@test "imgout" {
+  run docker container run --rm ${DOCKER_IMAGE} imgout -h
+  [ "$output" = 'usage: imgout [-f <font>]' ]
+}
+
+@test "zws" {
+  run docker container run --rm ${DOCKER_IMAGE} bash -c "echo J+KBouKAjeKAi+KBouKAjeKAi+KAi+KAjeKAjeKBouKAjOKBouKBouKAjeKAi+KBouKAjeKAi+KAi+KAjeKAjeKAjeKAjOKBouKBouKAjeKAi+KBouKAjeKAi+KAi+KBouKAjeKAjeKAjeKBouKBouKAjeKAjeKAi+KAjeKAi+KAjeKAjeKAjeKBouKAjeKAi+KAi+KAi+KAjeKAjScK | base64 -d | ./zws -d"
+  [ "$output" = 'シェル芸' ]
+}
+
+@test "osquery" {
+  run docker container run --rm ${DOCKER_IMAGE} osqueryi --version
+  [[ "$output" =~ 'osqueryi version ' ]]
+}
+
+@test "onefetch" {
+  run docker container run --rm ${DOCKER_IMAGE} bash -c "cd /ShellGeiData && onefetch | sed $'s/\033[^m]*m//g'"
+  [[ "${lines[0]}" =~ 'Project: ShellGeiData' ]]
+}
+
+@test "sushiro" {
+  run docker container run --rm ${DOCKER_IMAGE} sushiro -h
+  [[ "${lines[0]}" =~ 'sushiro version ' ]]
+}
+
+@test "noc" {
+  run docker container run --rm ${DOCKER_IMAGE} bash -c "echo 部邊邊󠄓邊󠄓邉邉󠄊邊邊󠄒邊󠄓邊󠄓邉邉󠄊辺邉󠄊邊邊󠄓邊󠄓邉邉󠄎辺邉󠄎邊辺󠄀邉邉󠄈辺邉󠄍邊邊󠄓部 | mono noc -d"
+  [ "$output" = 'シェル芸' ]
+}
+
+@test "bat" {
+  run docker container run --rm ${DOCKER_IMAGE} bat --version
+  [[ "$output" =~ "bat " ]]
+}
+
+@test "echo-meme" {
+  run docker container run --rm ${DOCKER_IMAGE} echo-meme シェル芸
+  [[ "$output" =~ "シェル芸" ]]
+}
+
+@test "bash 5.0" {
+  run docker container run --rm ${DOCKER_IMAGE} bash --version
+  [[ "${lines[0]}" =~ "GNU bash, バージョン 5.0" ]]
+}
+
+@test "awk 5.0" {
+  run docker container run --rm ${DOCKER_IMAGE} /usr/local/bin/awk --version
+  [[ "${lines[0]}" =~ "GNU Awk 5.0" ]]
+}
+
+@test "reiwa" {
+  run docker container run --rm ${DOCKER_IMAGE} date -d '2019-05-01' '+%Ec'
+  [ "$output" = '令和元年05月01日 00時00分00秒' ]
+}
+
+@test "NormalizationTest.txt" {
+  run docker container run --rm ${DOCKER_IMAGE} stat NormalizationTest.txt
+  [ "${lines[0]}" = '  File: NormalizationTest.txt' ]
+}
+
+@test "NamesList.txt" {
+  run docker container run --rm ${DOCKER_IMAGE} stat NamesList.txt
+  [ "${lines[0]}" = '  File: NamesList.txt' ]
+}
+
+@test "ke2dair" {
+  run docker container run --rm ${DOCKER_IMAGE} bash -c "echo シェル 芸 | ke2daira"
+  [ "$output" = 'ゲェル シイ' ]
+}

--- a/docker_image.bats
+++ b/docker_image.bats
@@ -228,8 +228,8 @@
 }
 
 @test "lolcat" {
-  run docker container run --rm ${DOCKER_IMAGE} which lolcat
-  [ "$output" = "/usr/games/lolcat" ]
+  run docker container run --rm ${DOCKER_IMAGE} lolcat --version
+  [[ "${lines[0]}" =~ "lolcat" ]]
 }
 
 @test "nyancat" {
@@ -243,8 +243,8 @@
 }
 
 @test "moreutils" {
-  run docker container run --rm ${DOCKER_IMAGE} which pee
-  [ "$output" = "/usr/bin/pee" ]
+  run docker container run --rm ${DOCKER_IMAGE} errno 1
+  [ "$output" = "EPERM 1 許可されていない操作です" ]
 }
 
 # strace は docker 上で実行する場合、--cap-add=SYS_PTRACE と --security-opt="seccomp=unconfined" が必要になるため、不要では
@@ -301,8 +301,9 @@
 }
 
 @test "telnet" {
-  run docker container run --rm ${DOCKER_IMAGE} which telnet
-  [ "$output" = "/usr/bin/telnet" ]
+  run docker container run --rm ${DOCKER_IMAGE} telnet -h
+  [ $status -eq 1 ]
+  [ "${lines[0]}" = "telnet: invalid option -- 'h'" ]
 }
 
 @test "busybox" {
@@ -643,8 +644,8 @@
 }
 
 @test "whitespace" {
-  run docker container run --rm ${DOCKER_IMAGE} which whitespace
-  [ "$output" = '/usr/local/bin/whitespace' ]
+  run docker container run --rm ${DOCKER_IMAGE} bash -c "echo -e '   \t \t  \t\t\n\t\n     \t\t \t   \n\t\n     \t\t  \t \t\n\t\n     \t\t \t\t  \n\t\n     \t\t \t\t  \n\t\n     \t   \t\t\t\n\t\n     \t\t  \t \t\n\t\n     \t\t \t  \t\n\t\n  \n\n' | whitespace"
+  [ "$output" = 'ShellGei' ]
 }
 
 @test "Open usp Tukubai" {


### PR DESCRIPTION
resolve #16

- [x] Multi Stage Build 対応
- [x] BuildKit 対応
- [x] 以前と同様にコマンドが動く自信がないのでテスト書く
- [x] jconsole の PATH 順序修正
- [x] `$GOPATH/src/github.com/YuheiNakasaka/sayhuuzoku/scraping/shoplist.txt` がよく使われるため、イメージに含める
- [x] 再配布になるため、(取りこぼした) 各ライセンスファイルを Docker イメージに含める
- [x] CircleCI にテストを組み込む
- ~~CircleCI キャッシュ最適化~~

---

メモ：

- bats を利用して新旧比較用のテストを書いたが、オリジナルの Docker イメージには bats が含まれていないため、毎回 `docker container run` を実行しているためテストが遅い
  - テスト時に bats をボリュームマウントして PATH を通してしまえば、毎回起動しなくてよさそう
  - あるいは、Docker イメージに bats を含めてしまうか
- BuildKit 対応
  - `RUN --mount=type=cache` はまだ [experimental](https://github.com/moby/buildkit/blob/master/frontend/dockerfile/docs/experimental.md#run---mounttypecache) な機能
- CircleCI キャッシュ最適化
  - BuildKit の Layer キャッシュはまだサポートされていないため、がんばってチューニングする必要があるが、メンテナンスが難しくなりそうなのが懸念
  - ローカルでのビルドはだいぶキャッシュが効き、試行錯誤しやすくなったはずなので、ここでは対応しないことにする
  - ストレージを結構食うため、キャッシュを吹き飛ばしたい場合は `$ docker system prune` で
  - キャッシュを無効にしてビルドするなら、`$ docker build -t shellgeibot --no-cache .` で
