### PR TITLE
DockerイメージのGolangパッケージ配置を効率化

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,20 +38,11 @@ jobs:
           docker_layer_caching: true  # BuildKit の DLC はまだ効かないっぽい
           version: "18.09.3"
       - run:
-          name: Setup Build environment
-          command: |
-            apk add bash bats --no-progress
-            bats --version
-            docker version
-      - run:
           name: Login Docker Hub
           command: docker login -u ${DOCKER_USER} -p ${DOCKER_PASS}
       - run:
           name: Build Docker image
           command: docker build -t ${DOCKER_IMAGE} --progress=plain .
-      - run:
-          name: Test Docker image
-          command: DOCKER_IMAGE=${DOCKER_IMAGE} bats docker_image.bats
       - run:
           name: Push Docker image to Docker Hub
           command: |


### PR DESCRIPTION
- CircleCI でのビルド時テストを廃止しました
- ランタイムコンテナでの Golang 関連ダウンロードをやめ、Golang ビルド用コンテナで取得、展開したものを再利用するよう修正しました
    - Golang 本体のソースコード類を含めないようにし、約 300MB ほどダイエットしました
    - ランタイムコンテナでの `go get` 等はできなくなったと思います

```
REPOSITORY          TAG                 IMAGE ID            CREATED             SIZE
shellgeibot         so                  10116b2913aa        7 minutes ago       7.16GB
shellgeibot         latest              2d44aa3b4ff2        28 hours ago        7.46GB
```
