### PR TITLE
Mitigate infinite recursion

### DIFF
--- a/main.go
+++ b/main.go
@@ -42,7 +42,7 @@ func processTweet(tweet anaconda.Tweet, self anaconda.User, api *anaconda.Twitte
 		log.Println(err)
 		return
 	}
-	text, mediaUrls, err := extractShellgei(tweet, self, api, config.Tags)
+	text, mediaUrls, err := extractShellgei(tweet, self, api, config.Tags,0)
 	if err != nil {
 		log.Println(err)
 		return

--- a/main.go
+++ b/main.go
@@ -42,7 +42,7 @@ func processTweet(tweet anaconda.Tweet, self anaconda.User, api *anaconda.Twitte
 		log.Println(err)
 		return
 	}
-	text, mediaUrls, err := extractShellgei(tweet, self, api, config.Tags,0)
+	text, mediaUrls, err := extractShellgei(tweet, self, api, config.Tags,[]int64{})
 	if err != nil {
 		log.Println(err)
 		return

--- a/tweet.go
+++ b/tweet.go
@@ -29,10 +29,15 @@ type tweetEntitiesHashtags []struct {
 	Text    string
 }
 
-func extractShellgei(tweet anaconda.Tweet, self anaconda.User, api *anaconda.TwitterApi, tags []string) (string, []string, error) {
+func extractShellgei(tweet anaconda.Tweet, self anaconda.User, api *anaconda.TwitterApi, tags []string,recursion int) (string, []string, error) {
 	// self recursion
 	if tweet.QuotedStatusID == tweet.Id {
 		return "", nil, fmt.Errorf("self recursion")
+	}
+
+	//Too many recursion
+	if recursion >= 5{
+		return "", nil, fmt.Errorf("too many recursion")
 	}
 
 	// if it is quoted tweet of shellgeibot's tweet
@@ -48,7 +53,7 @@ func extractShellgei(tweet anaconda.Tweet, self anaconda.User, api *anaconda.Twi
 		if err != nil {
 			return "", nil, err
 		}
-		return extractShellgei(quoted, self, api, tags)
+		return extractShellgei(quoted, self, api, tags,recursion+1)
 	}
 
 	// get tweet text
@@ -92,7 +97,7 @@ func extractShellgei(tweet anaconda.Tweet, self anaconda.User, api *anaconda.Twi
 		return "", nil, err
 	}
 
-	quoteText, quoteUrls, err := extractShellgei(quoted, self, api, tags)
+	quoteText, quoteUrls, err := extractShellgei(quoted, self, api, tags,recursion+1)
 	if err != nil {
 		return "", nil, err
 	}

--- a/tweet.go
+++ b/tweet.go
@@ -55,7 +55,7 @@ func extractShellgei(tweet anaconda.Tweet, self anaconda.User, api *anaconda.Twi
 		if err != nil {
 			return "", nil, err
 		}
-		return extractShellgei(quoted, self, api, tags,append(checked,tweet.QuotedStatusID))
+		return extractShellgei(quoted, self, api, tags,append(checked,tweet.Id))
 	}
 
 	// get tweet text
@@ -99,7 +99,7 @@ func extractShellgei(tweet anaconda.Tweet, self anaconda.User, api *anaconda.Twi
 		return "", nil, err
 	}
 
-	quoteText, quoteUrls, err := extractShellgei(quoted, self, api, tags,append(checked,tweet.QuotedStatusID))
+	quoteText, quoteUrls, err := extractShellgei(quoted, self, api, tags,append(checked,tweet.Id))
 	if err != nil {
 		return "", nil, err
 	}

--- a/tweet.go
+++ b/tweet.go
@@ -29,15 +29,17 @@ type tweetEntitiesHashtags []struct {
 	Text    string
 }
 
-func extractShellgei(tweet anaconda.Tweet, self anaconda.User, api *anaconda.TwitterApi, tags []string,recursion int) (string, []string, error) {
+func extractShellgei(tweet anaconda.Tweet, self anaconda.User, api *anaconda.TwitterApi, tags []string, checked []int64) (string, []string, error) {
 	// self recursion
 	if tweet.QuotedStatusID == tweet.Id {
 		return "", nil, fmt.Errorf("self recursion")
 	}
 
-	//Too many recursion
-	if recursion >= 5{
-		return "", nil, fmt.Errorf("too many recursion")
+	//Recursion Detected
+	for _, v := range checked {
+		if tweet.QuotedStatusID == v {
+			return "", nil, fmt.Errorf("recursion detected")
+		}
 	}
 
 	// if it is quoted tweet of shellgeibot's tweet
@@ -53,7 +55,7 @@ func extractShellgei(tweet anaconda.Tweet, self anaconda.User, api *anaconda.Twi
 		if err != nil {
 			return "", nil, err
 		}
-		return extractShellgei(quoted, self, api, tags,recursion+1)
+		return extractShellgei(quoted, self, api, tags,append(checked,tweet.QuotedStatusID))
 	}
 
 	// get tweet text
@@ -97,7 +99,7 @@ func extractShellgei(tweet anaconda.Tweet, self anaconda.User, api *anaconda.Twi
 		return "", nil, err
 	}
 
-	quoteText, quoteUrls, err := extractShellgei(quoted, self, api, tags,recursion+1)
+	quoteText, quoteUrls, err := extractShellgei(quoted, self, api, tags,append(checked,tweet.QuotedStatusID))
 	if err != nil {
 		return "", nil, err
 	}


### PR DESCRIPTION
### 要約
tweet.goにおいて、2つ以上のツイートを再帰的に引用した場合の判定が行われていなかったため、無限ループを起こせた問題の修正。

### 説明
自身を参照する再帰的ツイートは、[tweet.goの34行目から36行目](https://github.com/theoldmoon0602/ShellgeiBot/blob/master/tweet.go#L34)で処理しないように設計されていますが、2つ以上のツイートを再帰的に繋げた場合(1つ目のツイートで2つ目のツイートIDを当て、2つ目のツイートで1つ目のツイートを参照した場合)はこの制限を回避することが出来ます(...多分)。
時間と運を要するため、PoCは作成していませんが、(多分)実際に攻撃可能(だと思うけど自信がない)です。(ちなみにPoCが出来ていないためコードのテストもしてません。)
これによる攻撃が発生した場合、Botの応答が停止したりはしませんが([main.goの115行目](https://github.com/theoldmoon0602/ShellgeiBot/blob/master/main.go#L115)にて非同期になっているため)、何度も繰り返すことによりリソースを過度に消費させることが可能(かもしれないけどわからない)です。