### PR TITLE
READMEのjsonサンプルの拡張子をjsにした

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ An example of TwitterConfig.json
 
 An example of ShellgeiConfig.json
 
-```json
+```js
 {
 	"dockerimage": "theoldmoon0602/shellgeibot:master",
 	"timeout": "20s",  // timeout


### PR DESCRIPTION
READMEでコメントの部分が赤くハイライトされているのが気になったので
jsonではなくjsにしました。
(jsonにはコメント記法が存在しないためシンタックスエラーになっていた)