### PR TITLE
exec commandの代わりにdocker sdkを使用する

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,11 +6,17 @@ require (
 	github.com/ChimeraCoder/anaconda v2.0.0+incompatible
 	github.com/ChimeraCoder/tokenbucket v0.0.0-20131201223612-c5a927568de7 // indirect
 	github.com/azr/backoff v0.0.0-20160115115103-53511d3c7330 // indirect
+	github.com/docker/distribution v2.7.1+incompatible // indirect
+	github.com/docker/docker v1.13.1
+	github.com/docker/go-connections v0.4.0 // indirect
+	github.com/docker/go-units v0.4.0 // indirect
 	github.com/dustin/go-jsonpointer v0.0.0-20160814072949-ba0abeacc3dc // indirect
 	github.com/dustin/gojson v0.0.0-20160307161227-2e71ec9dd5ad // indirect
 	github.com/garyburd/go-oauth v0.0.0-20180319155456-bca2e7f09a17 // indirect
 	github.com/mattn/go-sixel v0.0.0-20190320171103-a8fac8fa7d81
 	github.com/mattn/go-sqlite3 v1.11.0
+	github.com/opencontainers/go-digest v1.0.0-rc1 // indirect
+	github.com/pkg/errors v0.9.1 // indirect
 	github.com/soniakeys/quant v1.0.0 // indirect
 	github.com/stretchr/testify v1.4.0
 	golang.org/x/net v0.0.0-20190813141303-74dc4d7220e7 // indirect

--- a/go.sum
+++ b/go.sum
@@ -6,6 +6,14 @@ github.com/azr/backoff v0.0.0-20160115115103-53511d3c7330 h1:ekDALXAVvY/Ub1UtNta
 github.com/azr/backoff v0.0.0-20160115115103-53511d3c7330/go.mod h1:nH+k0SvAt3HeiYyOlJpLLv1HG1p7KWP7qU9QPp2/pCo=
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/docker/distribution v2.7.1+incompatible h1:a5mlkVzth6W5A4fOsS3D2EO5BUmsJpcB+cRlLU7cSug=
+github.com/docker/distribution v2.7.1+incompatible/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=
+github.com/docker/docker v1.13.1 h1:IkZjBSIc8hBjLpqeAbeE5mca5mNgeatLHBy3GO78BWo=
+github.com/docker/docker v1.13.1/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
+github.com/docker/go-connections v0.4.0 h1:El9xVISelRB7BuFusrZozjnkIM5YnzCViNKohAFqRJQ=
+github.com/docker/go-connections v0.4.0/go.mod h1:Gbd7IOopHjR8Iph03tsViu4nIes5XhDvyHbTtUxmeec=
+github.com/docker/go-units v0.4.0 h1:3uh0PgVws3nIA0Q+MwDC8yjEPf9zjRfZZWXZYDct3Tw=
+github.com/docker/go-units v0.4.0/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
 github.com/dustin/go-jsonpointer v0.0.0-20160814072949-ba0abeacc3dc h1:tP7tkU+vIsEOKiK+l/NSLN4uUtkyuxc6hgYpQeCWAeI=
 github.com/dustin/go-jsonpointer v0.0.0-20160814072949-ba0abeacc3dc/go.mod h1:ORH5Qp2bskd9NzSfKqAF7tKfONsEkCarTE5ESr/RVBw=
 github.com/dustin/gojson v0.0.0-20160307161227-2e71ec9dd5ad h1:Qk76DOWdOp+GlyDKBAG3Klr9cn7N+LcYc82AZ2S7+cA=
@@ -16,6 +24,10 @@ github.com/mattn/go-sixel v0.0.0-20190320171103-a8fac8fa7d81 h1:AiRo+166RFsFNOhK
 github.com/mattn/go-sixel v0.0.0-20190320171103-a8fac8fa7d81/go.mod h1:zlzhYSuMbLdRdrxfutExxGpC+Pf2uUTJ6GpVQ4LB5dc=
 github.com/mattn/go-sqlite3 v1.11.0 h1:LDdKkqtYlom37fkvqs8rMPFKAMe8+SgjbwZ6ex1/A/Q=
 github.com/mattn/go-sqlite3 v1.11.0/go.mod h1:FPy6KqzDD04eiIsT53CuJW3U88zkxoIYsOqkbpncsNc=
+github.com/opencontainers/go-digest v1.0.0-rc1 h1:WzifXhOVOEOuFYOJAW6aQqW0TooG2iki3E3Ii+WN7gQ=
+github.com/opencontainers/go-digest v1.0.0-rc1/go.mod h1:cMLVZDEM3+U2I4VmLI6N8jQYUd2OVphdqWwCJHrFt2s=
+github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
+github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/soniakeys/quant v1.0.0 h1:N1um9ktjbkZVcywBVAAYpZYSHxEfJGzshHCxx/DaI0Y=

--- a/shellgei.go
+++ b/shellgei.go
@@ -164,7 +164,9 @@ func runCmd(cmdstr string, mediaUrls []string, config botConfig) (string, []stri
 				log.Printf("Unexpected RemoveVolume error : %v\n", err)
 			}
 		}
-		log.Printf("remove volume errror : %v", err)
+		if err != nil {
+				log.Printf("remove volume errror : %v", err)
+		}
 	}()
 
 	// create media directory

--- a/shellgei.go
+++ b/shellgei.go
@@ -147,7 +147,8 @@ func runCmd(cmdstr string, mediaUrls []string, config botConfig) (string, []stri
 	// c.f. https://github.com/theoldmoon0602/ShellgeiBot/issues/41
 	imagesVolume := name + "__volume"
 	defer func() {
-		_ = dkclient.VolumeRemove(ctx, imagesVolume, true)
+		err = dkclient.VolumeRemove(ctx, imagesVolume, true)
+		log.Printf("remove volume errror : %v", err)
 	}()
 
 	// create media directory
@@ -227,6 +228,10 @@ func runCmd(cmdstr string, mediaUrls []string, config botConfig) (string, []stri
 	if err != nil {
 		return "", []string{}, fmt.Errorf("error: %v, could not container create correctly", err)
 	}
+	defer func() {
+		_ = dkclient.ContainerStop(ctx, resp.ID, nil)
+	}()
+	log.Printf("container ID : %v", resp.ID)
 
 	if err := dkclient.ContainerStart(ctx, resp.ID, types.ContainerStartOptions{}); err != nil {
 		return "", []string{}, fmt.Errorf("error: %v ContainerStartError", err)
@@ -321,9 +326,6 @@ func getImagesFromDockerVolume(dstPath, vol string, size int64) error {
 	if err != nil {
 		return err
 	}
-	defer func() {
-		_ = dkclient.VolumeRemove(ctx, vol, true)
-	}()
 
 	if err := dkclient.ContainerStart(ctx, resp.ID, types.ContainerStartOptions{}); err != nil {
 		return err

--- a/shellgei_test.go
+++ b/shellgei_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"encoding/base64"
 	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"testing"
 	"time"
@@ -84,6 +86,44 @@ func TestRunCmd(t *testing.T) {
 			t.Errorf("got %+v, expected length 1", imgs)
 		} else if got, expected := imgs[0], base64.StdEncoding.EncodeToString([]byte("goodbye\n")); got != expected {
 			t.Errorf("got %v, expected %v", got, expected)
+		}
+	})
+
+	t.Run("with media urls", func(t *testing.T) {
+		urls := []string{"a.png", "b.png"}
+		mux := http.NewServeMux()
+		for _, url := range urls {
+			url := url
+			mux.HandleFunc(
+				"/"+url,
+				func(w http.ResponseWriter, r *http.Request) {
+					w.WriteHeader(http.StatusOK)
+					w.Write([]byte("hello-" + url))
+				},
+			)
+		}
+		ts := httptest.NewServer(mux)
+		defer ts.Close()
+		for i := range urls {
+			urls[i] = ts.URL + "/" + urls[i]
+		}
+
+		out, imgs, err := runCmd("cat /media/0 /media/1", urls, botConfig{
+			DockerImage: dockerImage,
+			Workdir:     "/tmp",
+			Memory:      "100M",
+			MediaSize:   250,
+			Timeout:     time.Duration(20 * time.Second),
+			Tags:        []string{},
+		})
+		if err != nil {
+			t.Fatalf("unexpected error, %v", err)
+		}
+		if expected := "hello-a.pnghello-b.png"; out != expected {
+			t.Errorf("got %q, expected %v", out, expected)
+		}
+		if len(imgs) != 0 {
+			t.Errorf("got %+v, expected empty", imgs)
 		}
 	})
 

--- a/shellgei_test.go
+++ b/shellgei_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"encoding/base64"
 	"os"
 	"os/exec"
@@ -76,20 +77,20 @@ func TestRunCmd(t *testing.T) {
 		}
 	})
 
-	// t.Run("check timeout", func(t *testing.T) {
-	// 	out, imgs, err := runCmd("sleep 2", nil, botConfig{
-	// 		DockerImage: dockerImage,
-	// 		Workdir:     "/tmp",
-	// 		Memory:      "100M",
-	// 		MediaSize:   250,
-	// 		Timeout:     time.Duration(1 * time.Second),
-	// 		Tags:        []string{},
-	// 	})
-	// 	if err != context.DeadlineExceeded {
-	// 		t.Fatalf("unexpected error, %v", err)
-	// 	}
-	// 	if len(imgs) != 0 && out == "" {
-	// 		t.Errorf("got %+v, expected empty", imgs)
-	// 	}
-	// })
+	t.Run("check timeout", func(t *testing.T) {
+		out, imgs, err := runCmd("sleep 2", nil, botConfig{
+			DockerImage: dockerImage,
+			Workdir:     "/tmp",
+			Memory:      "100M",
+			MediaSize:   250,
+			Timeout:     time.Duration(1 * time.Second),
+			Tags:        []string{},
+		})
+		if err != context.DeadlineExceeded {
+			t.Fatalf("unexpected error, %v", err)
+		}
+		if len(imgs) != 0 && out == "" {
+			t.Errorf("got %+v, expected empty", imgs)
+		}
+	})
 }

--- a/shellgei_test.go
+++ b/shellgei_test.go
@@ -2,8 +2,6 @@ package main
 
 import (
 	"encoding/base64"
-	"net/http"
-	"net/http/httptest"
 	"os"
 	"os/exec"
 	"testing"
@@ -78,41 +76,20 @@ func TestRunCmd(t *testing.T) {
 		}
 	})
 
-	t.Run("with media urls", func(t *testing.T) {
-		urls := []string{"a.png", "b.png"}
-		mux := http.NewServeMux()
-		for _, url := range urls {
-			url := url
-			mux.HandleFunc(
-				"/"+url,
-				func(w http.ResponseWriter, r *http.Request) {
-					w.WriteHeader(http.StatusOK)
-					w.Write([]byte("hello-" + url))
-				},
-			)
-		}
-		ts := httptest.NewServer(mux)
-		defer ts.Close()
-		for i := range urls {
-			urls[i] = ts.URL + "/" + urls[i]
-		}
-
-		out, imgs, err := runCmd("cat /media/0 /media/1", urls, botConfig{
-			DockerImage: dockerImage,
-			Workdir:     "/tmp",
-			Memory:      "100M",
-			MediaSize:   250,
-			Timeout:     time.Duration(20 * time.Second),
-			Tags:        []string{},
-		})
-		if err != nil {
-			t.Fatalf("unexpected error, %v", err)
-		}
-		if expected := "hello-a.pnghello-b.png"; out != expected {
-			t.Errorf("got %q, expected %v", out, expected)
-		}
-		if len(imgs) != 0 {
-			t.Errorf("got %+v, expected empty", imgs)
-		}
-	})
+	// t.Run("check timeout", func(t *testing.T) {
+	// 	out, imgs, err := runCmd("sleep 2", nil, botConfig{
+	// 		DockerImage: dockerImage,
+	// 		Workdir:     "/tmp",
+	// 		Memory:      "100M",
+	// 		MediaSize:   250,
+	// 		Timeout:     time.Duration(1 * time.Second),
+	// 		Tags:        []string{},
+	// 	})
+	// 	if err != context.DeadlineExceeded {
+	// 		t.Fatalf("unexpected error, %v", err)
+	// 	}
+	// 	if len(imgs) != 0 && out == "" {
+	// 		t.Errorf("got %+v, expected empty", imgs)
+	// 	}
+	// })
 }


### PR DESCRIPTION
docker sdkを使用することでコードの可読性を高めてみました
https://pkg.go.dev/github.com/docker/docker/client

また、timeoutをした場合のテストも追加しました。

主には `shellgei.go` 内にある `exec.Command()` の関数を対応した関数に置き換えました。
また、 `shellgei_test.go` の `setupDocker` にある部分も改修しています。