### PR TITLE
Shellcheck

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
-for f in `ls -A poc/*`; do
+for f in poc/.[!\.]* poc/*; do
     echo "test $f"
     mkdir testdir
     ./ShellgeiBot -test test_config.json "$f" &&
-    [[ "$(ls -A testdir | wc -l)" -eq "0" ]] && echo OK || echo NG
+    [[ -z "$(ls -A testdir)" ]] && echo OK || echo NG
     rm -r testdir
     echo -e "==============================================\n"
 done


### PR DESCRIPTION
`test.sh`に出ていた[shellcheck](https://www.shellcheck.net/)エラーを修正しました。

```bash
$ shellcheck test.sh

Line 2:
for f in `ls -A poc/*`; do
         ^-- SC2045: Iterating over ls output is fragile. Use globs.
         ^-- SC2006: Use $(...) notation instead of legacy backticked `...`.

Did you mean: (apply this, apply all SC2006)
for f in $(ls -A poc/*); do
 
Line 6:
    [[ "$(ls -A testdir | wc -l)" -eq "0" ]] && echo OK || echo NG
          ^-- SC2012: Use find instead of ls to better handle non-alphanumeric filenames.
```